### PR TITLE
Fix asymmetric Gaussian CDF normalization

### DIFF
--- a/asymmetric_uncertainty/core.py
+++ b/asymmetric_uncertainty/core.py
@@ -95,9 +95,10 @@ class a_u:
         Computes and returns the values of the cumulative distribution function for the specified input.
         """
         x_arr = np.asanyarray(x).astype(float)
+        width_sum = self.plus + self.minus
         cdf_arr = np.piecewise(x_arr, [x_arr<self.value, x_arr>=self.value],
-                               [lambda x: 0.5*(1 + np_erf((x-self.value)/(self.minus*np.sqrt(2)))),
-                                lambda x: 0.5*(1 + np_erf((x-self.value)/(self.plus*np.sqrt(2))))])
+                               [lambda x: self.minus/width_sum * (1 + np_erf((x-self.value)/(self.minus*np.sqrt(2)))),
+                                lambda x: (self.minus + self.plus*np_erf((x-self.value)/(self.plus*np.sqrt(2))))/width_sum])
         return cdf_arr.item() if np.isscalar(x) else cdf_arr
     
     def pdfplot(self,num_sigma=5,discretization=100,**kwargs):

--- a/asymmetric_uncertainty/tests/test_core.py
+++ b/asymmetric_uncertainty/tests/test_core.py
@@ -55,7 +55,6 @@ class TestCore(unittest.TestCase):
     def test_Distribution(self):
 
         width_sum = self.testValue.plus + self.testValue.minus
-        trapezoid = getattr(np, "trapezoid", np.trapz)
 
         self.assertAlmostEqual(
             self.testValue.cdf(self.testValue.value),
@@ -76,10 +75,10 @@ class TestCore(unittest.TestCase):
         )
         x = np.concatenate((neg_x[:-1], pos_x))
         pdf = self.testValue.pdf(x)
-        self.assertAlmostEqual(trapezoid(pdf, x), 1.0, places=6)
+        self.assertAlmostEqual(np.trapezoid(pdf, x), 1.0, places=6)
 
         self.assertAlmostEqual(
-            trapezoid(self.testValue.pdf(neg_x), neg_x),
+            np.trapezoid(self.testValue.pdf(neg_x), neg_x),
             self.testValue.cdf(self.testValue.value),
             places=6,
         )

--- a/asymmetric_uncertainty/tests/test_core.py
+++ b/asymmetric_uncertainty/tests/test_core.py
@@ -52,6 +52,38 @@ class TestCore(unittest.TestCase):
 
         self.assertAlmostEqual(self.testValue.sqrt().value, np.sqrt(3.0)) 
 
+    def test_Distribution(self):
+
+        width_sum = self.testValue.plus + self.testValue.minus
+        trapezoid = getattr(np, "trapezoid", np.trapz)
+
+        self.assertAlmostEqual(
+            self.testValue.cdf(self.testValue.value),
+            self.testValue.minus/width_sum,
+        )
+        self.assertAlmostEqual(self.testValue.cdf(-np.inf), 0.0)
+        self.assertAlmostEqual(self.testValue.cdf(np.inf), 1.0)
+
+        neg_x = np.linspace(
+            self.testValue.value - 10*self.testValue.minus,
+            self.testValue.value,
+            50001,
+        )
+        pos_x = np.linspace(
+            self.testValue.value,
+            self.testValue.value + 10*self.testValue.plus,
+            50001,
+        )
+        x = np.concatenate((neg_x[:-1], pos_x))
+        pdf = self.testValue.pdf(x)
+        self.assertAlmostEqual(trapezoid(pdf, x), 1.0, places=6)
+
+        self.assertAlmostEqual(
+            trapezoid(self.testValue.pdf(neg_x), neg_x),
+            self.testValue.cdf(self.testValue.value),
+            places=6,
+        )
+
     def test_Addition(self):
 
         testValue_c : a_u = self.testValue_a + self.testValue_b

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("./README.md", "r") as f:
 if __name__ == "__main__":
     setup(
         name="asymmetric_uncertainty",
-        version="0.2.4",
+        version="0.2.5",
         author="Caden Gobat",
         author_email="cgobat@gwu.edu",
         packages=find_packages(),


### PR DESCRIPTION
Updates `.cdf()` so it correctly integrates the jointly normalized asymmetric Gaussian PDF described by [John (1982)](https://doi.org/10.1080/03610928208828279) & [Starling *et al.* (2008)](https://doi.org/10.1086/521975). Adds regression tests for normalization and CDF/PDF consistency.