### PR TITLE
Avoid relative-error division at zero

### DIFF
--- a/asymmetric_uncertainty/core.py
+++ b/asymmetric_uncertainty/core.py
@@ -213,8 +213,8 @@ class a_u:
             other = a_u(other,0,0)
         
         result = self.value * other.value
-        pos = np.sqrt((self.plus/self.value)**2 + (other.plus/other.value)**2) * np.abs(result)
-        neg = np.sqrt((self.minus/self.value)**2 + (other.minus/other.value)**2) * np.abs(result)
+        pos = np.sqrt((self.plus*other.value)**2 + (other.plus*self.value)**2)
+        neg = np.sqrt((self.minus*other.value)**2 + (other.minus*self.value)**2)
         #print("multiplied",self,"by",other,"=",a_u(result,pos,neg))
         return a_u(result,pos,neg)
     
@@ -225,8 +225,8 @@ class a_u:
             other = a_u(other,0,0)
         
         result = self.value * other.value
-        pos = np.sqrt((self.plus/self.value)**2 + (other.plus/other.value)**2) * np.abs(result)
-        neg = np.sqrt((self.minus/self.value)**2 + (other.minus/other.value)**2) * np.abs(result)
+        pos = np.sqrt((self.plus*other.value)**2 + (other.plus*self.value)**2)
+        neg = np.sqrt((self.minus*other.value)**2 + (other.minus*self.value)**2)
         #print("multiplied",other,"by",self,"=",a_u(result,pos,neg))        
         return a_u(result,pos,neg)
     
@@ -236,8 +236,8 @@ class a_u:
         else:
             other = a_u(other,0,0)
         result = self.value / other.value
-        pos = np.sqrt((self.plus/self.value)**2 + (other.minus/other.value)**2) * np.abs(result)
-        neg = np.sqrt((self.minus/self.value)**2 + (other.plus/other.value)**2) * np.abs(result)
+        pos = np.sqrt((self.plus/other.value)**2 + (self.value*other.minus/other.value**2)**2)
+        neg = np.sqrt((self.minus/other.value)**2 + (self.value*other.plus/other.value**2)**2)
         #print("divided",self,"by",other,"=",a_u(result,pos,neg))        
         return a_u(result,pos,neg)
     
@@ -247,8 +247,8 @@ class a_u:
         else:
             other = a_u(other,0,0)
         result = other.value / self.value
-        pos = np.sqrt((other.plus/other.value)**2 + (self.minus/self.value)**2) * np.abs(result)
-        neg = np.sqrt((other.minus/other.value)**2 + (self.plus/self.value)**2) * np.abs(result)
+        pos = np.sqrt((other.plus/self.value)**2 + (other.value*self.minus/self.value**2)**2)
+        neg = np.sqrt((other.minus/self.value)**2 + (other.value*self.plus/self.value**2)**2)
         #print("divided",other,"by",self,"=",a_u(result,pos,neg))        
         return a_u(result,pos,neg)
     

--- a/asymmetric_uncertainty/tests/test_core.py
+++ b/asymmetric_uncertainty/tests/test_core.py
@@ -106,12 +106,40 @@ class TestCore(unittest.TestCase):
         self.assertAlmostEqual(testValue_c.plus, self.testValue_a.plus) 
         self.assertAlmostEqual(testValue_c.minus, self.testValue_a.minus)  
 
+    def test_Multiply_Zero(self):
+
+        zero_value = a_u(0.0, 0.1, 0.2)
+
+        result = zero_value * 2
+        self.assertAlmostEqual(result.value, 0.0)
+        self.assertAlmostEqual(result.plus, 0.2)
+        self.assertAlmostEqual(result.minus, 0.4)
+
+        result = self.testValue_a * 0
+        self.assertAlmostEqual(result.value, 0.0)
+        self.assertAlmostEqual(result.plus, 0.0)
+        self.assertAlmostEqual(result.minus, 0.0)
+
     def test_Divison_OverOne(self):
 
         testValue_c : a_u = self.testValue_a / self.testValue_one
 
         self.assertAlmostEqual(testValue_c.plus, self.testValue_a.plus) 
         self.assertAlmostEqual(testValue_c.minus, self.testValue_a.minus)  
+
+    def test_Division_Zero_Numerator(self):
+
+        zero_value = a_u(0.0, 0.1, 0.2)
+        result = zero_value / 2
+
+        self.assertAlmostEqual(result.value, 0.0)
+        self.assertAlmostEqual(result.plus, 0.05)
+        self.assertAlmostEqual(result.minus, 0.1)
+
+        result = 0 / self.testValue_a
+        self.assertAlmostEqual(result.value, 0.0)
+        self.assertAlmostEqual(result.plus, 0.0)
+        self.assertAlmostEqual(result.minus, 0.0)
 
     def test_Divison_UnderOne(self):
         testValue_e : a_u = self.testValue_one/self.testValue_d

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("./README.md", "r") as f:
 if __name__ == "__main__":
     setup(
         name="asymmetric_uncertainty",
-        version="0.2.5",
+        version="0.2.6",
         author="Caden Gobat",
         author_email="cgobat@gwu.edu",
         packages=find_packages(),


### PR DESCRIPTION
Reworks multiplication and division uncertainty propagation to use absolute first-order derivatives instead of relative errors. This prevents NaN uncertainties when nominal values are zero.