### PR TITLE
Propagate errors by derivative sign

### DIFF
--- a/asymmetric_uncertainty/core.py
+++ b/asymmetric_uncertainty/core.py
@@ -18,6 +18,21 @@ from math import erf
 
 np_erf = np.vectorize(erf, doc="Vectorized error function at x.")  # prevents need for SciPy dependency
 
+def _propagated_errors(operands, derivatives):
+    """Return first-order asymmetric errors for the supplied partial derivatives."""
+    pos_terms = []
+    neg_terms = []
+    for operand, derivative in zip(operands, derivatives):
+        if derivative >= 0:
+            pos_error = operand.plus
+            neg_error = operand.minus
+        else:
+            pos_error = operand.minus
+            neg_error = operand.plus
+        pos_terms.append((derivative*pos_error)**2)
+        neg_terms.append((derivative*neg_error)**2)
+    return np.sqrt(np.sum(pos_terms)), np.sqrt(np.sum(neg_terms))
+
 class a_u:
     """
     Class for representing and handling propagation of asymmetric uncertainties assuming a pseudo-Gaussian
@@ -213,8 +228,7 @@ class a_u:
             other = a_u(other,0,0)
         
         result = self.value * other.value
-        pos = np.sqrt((self.plus*other.value)**2 + (other.plus*self.value)**2)
-        neg = np.sqrt((self.minus*other.value)**2 + (other.minus*self.value)**2)
+        pos, neg = _propagated_errors((self, other), (other.value, self.value))
         #print("multiplied",self,"by",other,"=",a_u(result,pos,neg))
         return a_u(result,pos,neg)
     
@@ -225,8 +239,7 @@ class a_u:
             other = a_u(other,0,0)
         
         result = self.value * other.value
-        pos = np.sqrt((self.plus*other.value)**2 + (other.plus*self.value)**2)
-        neg = np.sqrt((self.minus*other.value)**2 + (other.minus*self.value)**2)
+        pos, neg = _propagated_errors((self, other), (other.value, self.value))
         #print("multiplied",other,"by",self,"=",a_u(result,pos,neg))        
         return a_u(result,pos,neg)
     
@@ -236,8 +249,7 @@ class a_u:
         else:
             other = a_u(other,0,0)
         result = self.value / other.value
-        pos = np.sqrt((self.plus/other.value)**2 + (self.value*other.minus/other.value**2)**2)
-        neg = np.sqrt((self.minus/other.value)**2 + (self.value*other.plus/other.value**2)**2)
+        pos, neg = _propagated_errors((self, other), (1/other.value, -self.value/other.value**2))
         #print("divided",self,"by",other,"=",a_u(result,pos,neg))        
         return a_u(result,pos,neg)
     
@@ -247,8 +259,7 @@ class a_u:
         else:
             other = a_u(other,0,0)
         result = other.value / self.value
-        pos = np.sqrt((other.plus/self.value)**2 + (other.value*self.minus/self.value**2)**2)
-        neg = np.sqrt((other.minus/self.value)**2 + (other.value*self.plus/self.value**2)**2)
+        pos, neg = _propagated_errors((other, self), (1/self.value, -other.value/self.value**2))
         #print("divided",other,"by",self,"=",a_u(result,pos,neg))        
         return a_u(result,pos,neg)
     

--- a/asymmetric_uncertainty/tests/test_core.py
+++ b/asymmetric_uncertainty/tests/test_core.py
@@ -120,6 +120,17 @@ class TestCore(unittest.TestCase):
         self.assertAlmostEqual(result.plus, 0.0)
         self.assertAlmostEqual(result.minus, 0.0)
 
+    def test_Multiply_Negative(self):
+
+        result = self.testValue_a * -3
+        self.assertAlmostEqual(result.value, -30.0)
+        self.assertAlmostEqual(result.plus, 6.0)
+        self.assertAlmostEqual(result.minus, 3.0)
+
+        result = self.testValue_a * a_u(-3.0, 0.5, 1.0)
+        self.assertAlmostEqual(result.plus, np.sqrt(61.0))
+        self.assertAlmostEqual(result.minus, np.sqrt(109.0))
+
     def test_Divison_OverOne(self):
 
         testValue_c : a_u = self.testValue_a / self.testValue_one
@@ -140,6 +151,18 @@ class TestCore(unittest.TestCase):
         self.assertAlmostEqual(result.value, 0.0)
         self.assertAlmostEqual(result.plus, 0.0)
         self.assertAlmostEqual(result.minus, 0.0)
+
+    def test_Division_Negative(self):
+
+        result = self.testValue_a / -2
+        self.assertAlmostEqual(result.value, -5.0)
+        self.assertAlmostEqual(result.plus, 1.0)
+        self.assertAlmostEqual(result.minus, 0.5)
+
+        result = -20 / self.testValue_a
+        self.assertAlmostEqual(result.value, -2.0)
+        self.assertAlmostEqual(result.plus, 0.2)
+        self.assertAlmostEqual(result.minus, 0.4)
 
     def test_Divison_UnderOne(self):
         testValue_e : a_u = self.testValue_one/self.testValue_d

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("./README.md", "r") as f:
 if __name__ == "__main__":
     setup(
         name="asymmetric_uncertainty",
-        version="0.2.6",
+        version="0.2.7",
         author="Caden Gobat",
         author_email="cgobat@gwu.edu",
         packages=find_packages(),


### PR DESCRIPTION
Adds sign-aware uncertainty propagation so positive and negative error bounds are selected correctly when an operation reverses direction, such as multiplication or division by a negative value.