### PR TITLE
Keep derived state synchronized after mutation

### DIFF
--- a/asymmetric_uncertainty/core.py
+++ b/asymmetric_uncertainty/core.py
@@ -75,11 +75,23 @@ class a_u:
             self.value = float(nominal)
             self.plus = np.abs(float(pos_err))
             self.minus = np.abs(float(neg_err))
-        self.maximum = self.value+self.plus
-        self.minimum = self.value-self.minus
-        self.sign = 1 if self.value >= 0 else -1
-        self.is_symmetric = np.isclose(self.plus, self.minus)
-    
+
+    @property
+    def maximum(self):
+        return self.value + self.plus
+
+    @property
+    def minimum(self):
+        return self.value - self.minus
+
+    @property
+    def sign(self):
+        return 1 if self.value >= 0 else -1
+
+    @property
+    def is_symmetric(self):
+        return np.isclose(self.plus, self.minus)
+
     def __str__(self):
         return f"{self}"
     
@@ -452,6 +464,53 @@ class UncertaintyArray(list):
     def append(self, entry):
         super().append(entry)
         self.refresh()
+
+    def extend(self, iterable):
+        super().extend(iterable)
+        self.refresh()
+
+    def insert(self, index, entry):
+        super().insert(index, entry)
+        self.refresh()
+
+    def pop(self, index=-1):
+        entry = super().pop(index)
+        self.refresh()
+        return entry
+
+    def remove(self, entry):
+        super().remove(entry)
+        self.refresh()
+
+    def clear(self):
+        super().clear()
+        self.refresh()
+
+    def reverse(self):
+        super().reverse()
+        self.refresh()
+
+    def sort(self, *args, **kwargs):
+        super().sort(*args, **kwargs)
+        self.refresh()
+
+    def __setitem__(self, key, val):
+        super().__setitem__(key, val)
+        self.refresh()
+
+    def __delitem__(self, key):
+        super().__delitem__(key)
+        self.refresh()
+
+    def __iadd__(self, other):
+        super().__iadd__(other)
+        self.refresh()
+        return self
+
+    def __imul__(self, other):
+        super().__imul__(other)
+        self.refresh()
+        return self
 
     def pdf(self, x):
         return np.sum([entry.pdf(x) for entry in self], axis=0)

--- a/asymmetric_uncertainty/tests/test_core.py
+++ b/asymmetric_uncertainty/tests/test_core.py
@@ -239,3 +239,41 @@ class TestCore(unittest.TestCase):
         self.assertIs(popped, second)
         self.assertEqual(len(array), 1)
         self.assertEqual(array, [first])
+
+    def test_Derived_State_After_Mutation(self):
+
+        value = a_u(3.0, 0.2, 0.4)
+        value.add_error(0.3, method="straight", inplace=True)
+
+        self.assertAlmostEqual(value.maximum, 3.5)
+        self.assertAlmostEqual(value.minimum, 2.3)
+
+        value.minus = 0.5
+        self.assertTrue(value.is_symmetric)
+
+        value.value = -3.0
+        self.assertEqual(value.sign, -1)
+        self.assertAlmostEqual(value.maximum, -2.5)
+        self.assertAlmostEqual(value.minimum, -3.5)
+
+    def test_UncertaintyArray_State_After_Mutation(self):
+
+        array = UncertaintyArray([a_u(1.0, 0.1, 0.2)])
+
+        array[0] = 2.0
+        self.assertIsInstance(array[0], a_u)
+        self.assertEqual(array.values, [2.0])
+        self.assertEqual(array.plus, [0.0])
+        self.assertEqual(array.minus, [0.0])
+
+        array.extend([3.0, a_u(4.0, 0.4, 0.5)])
+        self.assertEqual(array.values, [2.0, 3.0, 4.0])
+        self.assertEqual(array.plus, [0.0, 0.0, 0.4])
+        self.assertEqual(array.minus, [0.0, 0.0, 0.5])
+
+        array.reverse()
+        self.assertEqual(array.values, [4.0, 3.0, 2.0])
+
+        array.pop()
+        self.assertEqual(array.values, [4.0, 3.0])
+        self.assertEqual(array.shape, (2,))

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("./README.md", "r") as f:
 if __name__ == "__main__":
     setup(
         name="asymmetric_uncertainty",
-        version="0.2.9",
+        version="0.2.10",
         author="Caden Gobat",
         author_email="cgobat@gwu.edu",
         packages=find_packages(),


### PR DESCRIPTION
Prevents stale cached values after in-place updates. Derived `a_u` properties are now computed dynamically (as `@property` methods instead of static attributes), and `UncertaintyArray` refreshes its cached array views after mutations.